### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,7 +15,7 @@ ESP8266	KEYWORD1
 
 begin	KEYWORD2
 connect	KEYWORD2
-start_server KEYWORD2
+start_server	KEYWORD2
 stop_server	KEYWORD2
 close_conns	KEYWORD2
 execute	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords